### PR TITLE
Add support for creating uefi images

### DIFF
--- a/image_builder/imagebuilder.py
+++ b/image_builder/imagebuilder.py
@@ -159,6 +159,10 @@ and try again.""")
             properties['hw_disk_bus'] = 'scsi'
             properties['hw_scsi_model'] = 'virtio-scsi'
 
+        if commands.bootstrap_args.efi:
+            properties['hw_firmware_type'] = 'uefi'
+            properties['hw_machine_type'] = 'q35'
+
         properties['hw_rng_model'] = 'virtio'
 
         bootstrap = BootstrapFunctions(ib_session,

--- a/image_builder/parsecommands.py
+++ b/image_builder/parsecommands.py
@@ -108,6 +108,10 @@ class Commands(object):
                             help='Do not create image with scsi disk properties',
                             action='store_true',
                             default=False)
+        parser.add_argument('-e', '--efi',
+                            help='Boot image with uefi boot firmware',
+                            action='store_true',
+                            default=False)
         parser.add_argument('-v', '--verbose',
                             help='Be verbose',
                             action='store_true',


### PR DESCRIPTION
Adds new efi bootstrap argument. Setting the argument will make imagebuilder tag the base image with uefi firmware before launching packer. 