### PR TITLE
Update example: Fix relative paths in template and supplement docs

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,13 +1,15 @@
 ## Example usage of imagebuilder
 
-This is tested on Alma Linux 8.7
+This is tested on Alma Linux 8.7. Beware of a duplicate packer executable in `/usr/sbin`, the correct one is in `/usr/bin`. Modify the order of $PATH to ensure the correct one is used.
 
 ### Install
 
 ``` bash
-<install packer repo>
+<install packer repo> # See Hashicorp Packer documentation
 dnf install -y packer python3-virtualenv python39
-cd <clone>
+PATH="/usr/bin:$PATH" # Make sure the executable in /usr/bin is used
+git clone https://github.com/norcams/imagebuilder imagebuilder
+cd imagebuilder/example
 virtualenv-3 -p /usr/bin/python3.9 .
 source bin/activate
 pip install --upgrade pip
@@ -15,7 +17,8 @@ pip install -r requirements.txt
 ```
 
 ### Build
-
+From the example directory, run:
 ``` bash
-imagebuilder build -n test-image-el8-$(date +%Y-%m-%d) -s $(openstack image show 'GOLD Alma Linux 8' -c id -f value) -a bgo-default-1 -u almalinux -p provision.sh -v --debug
+source $HOME/keystore_rc.sh # Make credentials available in ENV. See NREC API documentation for details
+../imagebuilder build -n test-image-el8-$(date +%Y-%m-%d) -s $(openstack image show 'GOLD Alma Linux 8' -c id -f value) -a bgo-default-1 -u almalinux -p provision.sh -v --debug
 ```

--- a/example/template
+++ b/example/template
@@ -19,9 +19,9 @@
   }],
   "provisioners": [{
     "scripts": [
-      "src/imagebuilder/scripts/upgrade.sh",
+      "../scripts/upgrade.sh",
       "{{user `provision_script`}}",
-      "src/imagebuilder/scripts/cleanup.sh"
+      "../scripts/cleanup.sh"
     ],
     "type": "shell"
   }]


### PR DESCRIPTION
This commit is:
* Fixing two relative paths in the template file
* Adding some clarifications in the documentation regarding duplicate executable issue on RHEL based distros and Keystone auth